### PR TITLE
Make UI responsive with mobile-first Tailwind breakpoints

### DIFF
--- a/src/main/scala/UI.scala
+++ b/src/main/scala/UI.scala
@@ -32,13 +32,13 @@ object UI:
           header(
             `class` := "mb-8",
             div(
-              `class` := "flex items-center justify-between",
+              `class` := "flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3",
               h1(
                 `class` := "text-3xl font-bold text-gray-900",
                 a(href := "/", "SkillsJars"),
               ),
               nav(
-                `class` := "flex gap-1 bg-gray-200 rounded-lg p-1",
+                `class` := "flex gap-1 bg-gray-200 rounded-lg p-1 self-start sm:self-auto",
                 navLink("/", "Find SkillsJars", currentPath == "/"),
                 navLink("/docs", "Documentation", currentPath == "/docs"),
               ),
@@ -118,7 +118,7 @@ object UI:
         method := "post",
         Dom.attr("onsubmit", "var b=this.querySelector('button[type=submit]');b.disabled=true;b.textContent='Deploying...'"),
         div(
-          `class` := "flex gap-2 items-end",
+          `class` := "flex flex-col sm:flex-row gap-2 sm:items-end",
           div(
             `class` := "flex-1",
             label(`class` := "block text-sm font-medium text-gray-700 mb-1", `for` := "org", "GitHub Org"),
@@ -185,10 +185,10 @@ object UI:
     div(
       `class` := "bg-white rounded-lg shadow p-4",
       div(
-        `class` := "flex justify-between items-start",
+        `class` := "flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2",
         div(
           div(
-            `class` := "flex items-center gap-2",
+            `class` := "flex flex-wrap items-center gap-2",
             h3(`class` := "font-semibold text-gray-900", sj.name),
             if sj.securityScanned then
               span(`class` := "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800",
@@ -209,7 +209,7 @@ object UI:
           else Dom.empty,
         ),
         div(
-          `class` := "ml-4",
+          `class` := "sm:ml-4 self-start",
           versionSelect(sj),
         ),
       ),


### PR DESCRIPTION
## Summary
Updated the UI layout to be responsive across different screen sizes using Tailwind CSS's `sm:` breakpoints and flexbox utilities. The changes ensure the interface adapts gracefully from mobile to desktop viewports.

## Key Changes
- **Header layout**: Changed from fixed horizontal layout to stacked on mobile (`flex-col`) with horizontal alignment on small screens and up (`sm:flex-row`)
- **Navigation positioning**: Added `self-start` on mobile and `sm:self-auto` to properly align the nav menu
- **Form inputs**: Updated deployment form to stack vertically on mobile and horizontally on larger screens with proper alignment
- **SkillsJar cards**: 
  - Made the header section responsive with column/row switching based on screen size
  - Added `flex-wrap` to the name/badge row to handle wrapping on smaller screens
  - Adjusted version selector spacing with `sm:ml-4` and `self-start` for proper alignment
- **Spacing**: Added `gap-3` and `gap-2` utilities to maintain consistent spacing in responsive layouts

## Implementation Details
All changes use Tailwind's mobile-first approach where base styles apply to mobile and `sm:` prefixed utilities override them for small screens and up. This ensures the UI is mobile-friendly by default while providing optimized layouts for larger displays.

https://claude.ai/code/session_014afRjewGxM6rteXcc91WVf