### PR TITLE
Improve search input UX with inline clear button

### DIFF
--- a/src/main/scala/UI.scala
+++ b/src/main/scala/UI.scala
@@ -87,24 +87,27 @@ object UI:
       input(`type` := "hidden", name := "bt", value := buildTool.param),
       div(
         `class` := "flex gap-2",
-        input(
-          `type` := "text",
-          name := "q",
-          placeholder := "Search skills by name or description...",
-          `class` := "flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500",
-          maybeQuery.map(q => value := q).getOrElse(Dom.empty),
+        div(
+          `class` := "flex-1 relative",
+          input(
+            `type` := "text",
+            name := "q",
+            placeholder := "Search skills by name or description...",
+            `class` := s"w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500${maybeQuery.fold("")(_ => " pr-8")}",
+            maybeQuery.map(q => value := q).getOrElse(Dom.empty),
+          ),
+          maybeQuery.fold(Dom.empty): _ =>
+            a(
+              href := s"/?bt=${buildTool.param}",
+              `class` := "absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 cursor-pointer",
+              "✕",
+            ),
         ),
         button(
           `type` := "submit",
           `class` := "px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 cursor-pointer",
           "Search",
         ),
-        maybeQuery.fold(Dom.empty): _ =>
-          a(
-            href := s"/?bt=${buildTool.param}",
-            `class` := "px-6 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 cursor-pointer flex items-center",
-            "Clear",
-          ),
       ),
     )
 


### PR DESCRIPTION
## Summary
Refactored the search form layout to replace the separate "Clear" button with an inline clear button (✕) positioned inside the search input field, improving the user interface and reducing visual clutter.

## Key Changes
- Wrapped the search input in a relative-positioned container div to enable absolute positioning of the clear button
- Moved the clear button from a separate element to an inline icon positioned absolutely within the search input field
- Updated input styling to add right padding (`pr-8`) when a query is present, preventing text overlap with the clear button
- Removed the standalone "Clear" button element that was previously displayed next to the search button
- The clear button now uses a subtle "✕" character with hover effects instead of a full-width button

## Implementation Details
- The clear button is conditionally rendered only when `maybeQuery` has a value
- Positioned using `absolute right-2 top-1/2 -translate-y-1/2` for vertical and horizontal centering
- Styled with gray text that darkens on hover for better visual feedback
- Maintains the same functionality (links to `/?bt={buildTool.param}`) while providing a more compact UI

https://claude.ai/code/session_019Uh1AbHdhSbh57hjXMkQCo